### PR TITLE
Use env bash instead of fixed path.

### DIFF
--- a/caman
+++ b/caman
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Initialise


### PR DESCRIPTION
I had to use this for my BSD environment, but it looks like [a best practice](http://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash).