### PR TITLE
Add file based password store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ca/*
 !ca/caconfig.cnf.default
 !ca/host.cnf.default
 store/*
+.idea

--- a/caman
+++ b/caman
@@ -39,9 +39,24 @@ function call_openssl {
     # Wrapper for openssl which caches the CA password and makes it available
     # on openssl's password source "fd:0"
     if [[ -z ${CAPASS+x} ]] ; then
-        # CAPASS is not set - get password for this certificate authority
-        read -sp "Enter CA password for $CAMANDIR: " CAPASS
-        echo
+        if [[ -f "$CADIR/password" ]] ; then
+            CAPASS=$(<"$CADIR/password")
+        else
+            # CAPASS is not set - get password for this certificate authority
+            read -sp "Enter CA password for $CAMANDIR: " CAPASS
+            echo
+            if [[ 0 -eq ${#CAPASS} ]] ; then
+                touch "$CADIR/password" || exit 1
+                chmod 600 "$CADIR/password" || exit 1
+                read
+                (openssl rand -base64 33 || exit 1) > "$CADIR/password"
+                chmod 400 "$CADIR/password" || exit 1
+                CAPASS=$(<"$CADIR/password")
+                echo "Generated CA password stored in $CADIR/password"
+                echo "WARNING: CA password is stored in plain text. This is only appropriate in"
+                echo "WARNING: non-production situations, or if access to this store is secured."
+            fi
+        fi
     fi
 
     # Run the command or exit on failure

--- a/caman
+++ b/caman
@@ -48,7 +48,6 @@ function call_openssl {
             if [[ 0 -eq ${#CAPASS} ]] ; then
                 touch "$CADIR/password" || exit 1
                 chmod 600 "$CADIR/password" || exit 1
-                read
                 (openssl rand -base64 33 || exit 1) > "$CADIR/password"
                 chmod 400 "$CADIR/password" || exit 1
                 CAPASS=$(<"$CADIR/password")


### PR DESCRIPTION
CA password can now be stored in a file. If no password is entered, a random password will be generated into this file, which causes a warning to be printed. This is only intended to be used when no in a production setting, or if access to the entire caman installation is secured.