### PR TITLE
Add PKCS#12 generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ca/*
 !ca/caconfig.cnf.default
 !ca/host.cnf.default
 store/*
+.idea

--- a/caman
+++ b/caman
@@ -316,6 +316,23 @@ function command_sign_host {
         cat "$CERTDIR/$HOST.key.pem" "$CERTDIR/$HOST.crt.pem" \
             > "$CERTDIR/$HOST.keycrt.pem" \
             || exit 1
+
+        # Create password for PKCS12 stores
+        if [[ ! -f "$CERTDIR/password" ]] ; then
+            touch "$CERTDIR/password" || exit 1
+            chmod 600 "$CERTDIR/password" || exit 1
+            (openssl rand -base64 33 || exit 1) > "$CERTDIR/password"
+            chmod 400 "$CERTDIR/password" || exit 1
+        fi
+
+        # Create basic PKCS12 store
+        openssl pkcs12 -export \
+            -inkey "$CERTDIR/$HOST.key.pem" \
+            -in "$CERTDIR/$HOST.crt.pem" \
+            -out "$CERTDIR/$HOST.p12" \
+            -passout "file:$CERTDIR/password" \
+            || exit 1
+        chmod 400 "$CERTDIR/$HOST.p12" || exit 1
     fi
 
     # Create chained certs if this is an intermediate CA
@@ -328,6 +345,16 @@ function command_sign_host {
             cat "$CERTDIR/$HOST.key.pem" "$CERTDIR/$HOST.chained.crt.pem" \
                 > "$CERTDIR/$HOST.chained.keycrt.pem" \
                 || exit 1
+
+            # Create chained PKCS12 store
+            openssl pkcs12 -export \
+                -inkey "$CERTDIR/$HOST.key.pem" \
+                -in "$CERTDIR/$HOST.crt.pem" \
+                -certfile "$CADIR/ca-chain.crt.pem" \
+                -out "$CERTDIR/$HOST.chained.p12" \
+                -passout "file:$CERTDIR/password" \
+                || exit 1
+            chmod 400 "$CERTDIR/$HOST.chained.p12" || exit 1
         fi
     fi
     echo "Certificate generated"

--- a/caman
+++ b/caman
@@ -273,22 +273,29 @@ function command_sign_host {
     # Generate directory for this cert
     mkdir "$CERTDIR" || exit 1
 
-    # Create a new CSR and private key
-    # OpenSSL arguments:
-    #   req                 Command for CSR management
-    #   -new                Generate a new CSR
-    #   -sha256             Force OpenSSL to use SHA256
-    #   -newkey rsa:2048    Generate a new 2048 bit RSA private key
-    #   -nodes              Do not encrypt the private key
-    #   -keyout "..."       Path to save new key
-    #   -out "..."          Path to save new CSR
-    #   -config "..."       Path to host config created by ``new``
-    # No need for CA password here
-    echo "Creating CSR and private key..."
-    call_openssl req -sha256 \
-        -newkey rsa:2048 -nodes -keyout "$CERTDIR/$HOST.key.pem" \
-        -new -out "$CERTDIR/$HOST.csr" \
-        -config "$HOSTDIR/config.cnf" -batch
+    # If there is already a CSR, we don't need to create it, or the related pk
+    if [[ -f "$HOSTDIR/$HOST.csr" ]] ; then
+        echo "Using supplied CSR"
+        mv "$HOSTDIR/$HOST.csr" "$CERTDIR/$HOST.csr"
+    else
+
+        # Create a new CSR and private key
+        # OpenSSL arguments:
+        #   req                 Command for CSR management
+        #   -new                Generate a new CSR
+        #   -sha256             Force OpenSSL to use SHA256
+        #   -newkey rsa:2048    Generate a new 2048 bit RSA private key
+        #   -nodes              Do not encrypt the private key
+        #   -keyout "..."       Path to save new key
+        #   -out "..."          Path to save new CSR
+        #   -config "..."       Path to host config created by ``new``
+        # No need for CA password here
+        echo "Creating CSR and private key..."
+        call_openssl req -sha256 \
+            -newkey rsa:2048 -nodes -keyout "$CERTDIR/$HOST.key.pem" \
+            -new -out "$CERTDIR/$HOST.csr" \
+            -config "$HOSTDIR/config.cnf" -batch
+    fi
 
     # Sign the request
     # OpenSSL arguments:
@@ -304,10 +311,12 @@ function command_sign_host {
         -days $DAYS -notext \
         -config "$CADIR/caconfig.cnf"
 
-    # Concat the key and certificate
-    cat "$CERTDIR/$HOST.key.pem" "$CERTDIR/$HOST.crt.pem" \
-        > "$CERTDIR/$HOST.keycrt.pem" \
-        || exit 1
+    if [[ -f "$CERTDIR/$HOST.key.pem" ]] ; then
+        # Concat the key and certificate
+        cat "$CERTDIR/$HOST.key.pem" "$CERTDIR/$HOST.crt.pem" \
+            > "$CERTDIR/$HOST.keycrt.pem" \
+            || exit 1
+    fi
 
     # Create chained certs if this is an intermediate CA
     if [[ -f "$CADIR/ca-chain.crt.pem" ]] ; then
@@ -315,9 +324,11 @@ function command_sign_host {
             > "$CERTDIR/$HOST.chained.crt.pem" \
             || exit 1
 
-        cat "$CERTDIR/$HOST.key.pem" "$CERTDIR/$HOST.chained.crt.pem" \
-            > "$CERTDIR/$HOST.chained.keycrt.pem" \
-            || exit 1
+        if [[ -f "$CERTDIR/$HOST.key.pem" ]] ; then
+            cat "$CERTDIR/$HOST.key.pem" "$CERTDIR/$HOST.chained.crt.pem" \
+                > "$CERTDIR/$HOST.chained.keycrt.pem" \
+                || exit 1
+        fi
     fi
     echo "Certificate generated"
 }


### PR DESCRIPTION
Add generation of PKCS#12 files containing host private keys and certificates, these are entrypted using a random password stored in a password file next to the PKCS#12 file(s). As long as the priate key file is generated, the PKCS#12 file ($CERTDIR/$HOST.p12) and the password file ($CERTDIR/password) will be created. If the chained certificate file is also present, a chained PKCS#12 file will also be generated ($CERTDIR/$HOST.chained.p12) using the same password.

This depends on a previous pull request #12.