### PR TITLE
Add subjectAltName even for singular host

### DIFF
--- a/caman
+++ b/caman
@@ -240,7 +240,7 @@ function command_new {
             foreach $h (@hosts) {
                 $h = ($h =~ /^\d+(\.\d+){3}+$/ ? "IP:" : "DNS:") . $h;
             }
-            print "subjectAltName = " . join(", ", @hosts) . "\n" if @hosts > 1;
+            print "subjectAltName = " . join(", ", @hosts) . "\n" if @hosts;
         } else {
             print;
         }


### PR DESCRIPTION
So I learned something new today, which is that certs which specify their host using only the `commonName` field have been deprecated for quite some time, and all publicly-trusted CAs have included `subjectAltName` even for single-host certs since 2012.

I learned this when Chrome suddenly refused to recognize any of the certs signed by my private CA (I kept getting `net::ERR_CERT_COMMON_NAME_INVALID` errors, a name which now seems frustratingly imprecise). After much searching I found [this Chromium thread](https://groups.google.com/a/chromium.org/forum/m/#!topic/security-dev/IGT2fLJrAeo) in which they discuss requiring `subjectAltName`. I'm on the Chrome beta track and saw it recently updated to `58.0.3029.19 beta` so they must at least be testing this feature.

Anyway, I created new certs with `subjectAltName`s and the error went away, so here's the pull request. Thanks for the tool; it did exactly what I needed.