### PR TITLE
Standalone CRL command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ca/*
 !ca/caconfig.cnf.default
 !ca/host.cnf.default
 store/*
+.idea

--- a/caman
+++ b/caman
@@ -577,6 +577,10 @@ case "$CMD" in
 
         ;;
 
+    crl)
+        generate_crl
+
+        ;;
     *)
         cat <<EOF
 Caman version $VERSION
@@ -587,6 +591,7 @@ Usage:  caman init [ca:<path/to/root_ca>]
         caman renew <hostname>
         caman revoke <hostname>
         caman revoke ca:<path/to/intermediate_ca>
+        caman crl
 EOF
 
         ;;


### PR DESCRIPTION
Since CRLs expire after (by default) 30 days, it is occasionally necessary to generate them without revoking any certificates. The new command performs this task.