### PR TITLE
Add command which just re-generates the CRL

### DIFF
--- a/caman
+++ b/caman
@@ -487,6 +487,10 @@ case "$CMD" in
 
         ;;
 
+    crl)
+        generate_crl
+
+        ;;
     *)
         cat <<EOF
 Caman version $VERSION
@@ -497,6 +501,7 @@ Usage:  caman init [ca:<path/to/root_ca>]
         caman renew <hostname>
         caman revoke <hostname>
         caman revoke ca:<path/to/intermediate_ca>
+        caman crl
 EOF
 
         ;;


### PR DESCRIPTION
Since CRLs expire after (by default) 30 days, it is occasionally necessary to generate them without revoking any certificates. The new command performs this task.