### PR TITLE
Update caman

### DIFF
--- a/caman
+++ b/caman
@@ -311,7 +311,7 @@ function command_sign_host {
 
     # Create chained certs if this is an intermediate CA
     if [[ -f "$CADIR/ca-chain.crt.pem" ]] ; then
-        cat "$CERTDIR/$HOST.crt.pem" "$CADIR/ca-chain.crt.pem" \
+        cat "$CADIR/ca-chain.crt.pem" "$CERTDIR/$HOST.crt.pem" \
             > "$CERTDIR/$HOST.chained.crt.pem" \
             || exit 1
 


### PR DESCRIPTION
When bundling an intermediate with end-entity certificate, the intermediates must come before the end-entity.