### PR TITLE
Make SAN always present

### DIFF
--- a/caman
+++ b/caman
@@ -240,7 +240,7 @@ function command_new {
             foreach $h (@hosts) {
                 $h = ($h =~ /^\d+(\.\d+){3}+$/ ? "IP:" : "DNS:") . $h;
             }
-            print "subjectAltName = " . join(", ", @hosts) . "\n" if @hosts > 1;
+            print "subjectAltName = " . join(", ", @hosts) . "\n";
         } else {
             print;
         }


### PR DESCRIPTION
Validation against CN was deprecated in RFC 2818, SAN should be present even for single hostname